### PR TITLE
Add block timestamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.1.0",
     "react-markdown": "^8.0.3",
     "react-scripts": "5.0.1",
+    "readable-timestamp-js": "^1.0.2",
     "swr": "^1.3.0",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -76,6 +76,12 @@ function App() {
       title: "Timestamp",
       dataIndex: "timestamp",
       key: "timestamp",
+      render: (timestamp) => {
+        if (!timestamp) {
+          return <p>Loading...</p>;
+        }
+        return timestamp;
+      },
     },
   ];
 

--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import {
   Col,
 } from "antd";
 import { GithubOutlined } from "@ant-design/icons";
+import { timeDifferenceForDate } from "readable-timestamp-js";
 
 const { Header, Footer, Content } = Layout;
 
@@ -135,7 +136,7 @@ function App() {
           const time = await provider.getBlock(block);
           const timestamp = time.timestamp;
           const date = new Date(timestamp * 1000);
-          const newDate = date.toString();
+          const newDate = timeDifferenceForDate(date);
           timestampArr.push(newDate);
         }
         setTimestamps(timestampArr);

--- a/src/App.js
+++ b/src/App.js
@@ -38,7 +38,12 @@ function App() {
   const [timestamps, setTimestamps] = useState([]);
   const inputRef = useRef(null);
 
-  console.log(timestamps);
+  const addTimestamp = events.map((event, index) => ({
+    ...event,
+    timestamp: timestamps[index],
+  }));
+
+  console.log(addTimestamp);
 
   const { contractEvents, isLoading, isError } = GetData(contractAddress);
 
@@ -68,6 +73,11 @@ function App() {
       key: "blockNumber",
       sorter: (a, b) => a.blockNumber - b.blockNumber,
       sortOrder: "descend",
+    },
+    {
+      title: "Timestamp",
+      dataIndex: "timestamp",
+      key: "timestamp",
     },
   ];
 
@@ -113,22 +123,19 @@ function App() {
       setEvents(queryResult);
 
       const eventBlocks = queryResult.map((item) => item.blockNumber);
-      const uniqueBlocks = [...new Set(eventBlocks)];
+      // const uniqueBlocks = [...new Set(eventBlocks)];
 
       const timestampArr = [];
 
       async function getTimestamp() {
-        for (const block of uniqueBlocks) {
-          const timestampDict = {};
+        for (const block of eventBlocks) {
           const time = await provider.getBlock(block);
           const timestamp = time.timestamp;
-          timestampDict.block = block;
-          timestampDict.timestamp = timestamp;
-          timestampArr.push({ timestampDict: timestampDict });
+          const date = new Date(timestamp * 1000);
+          timestampArr.push(date);
         }
+        setTimestamps(timestampArr);
       }
-
-      setTimestamps(timestampArr);
 
       getTimestamp();
     };
@@ -196,7 +203,7 @@ function App() {
                   record.logIndex + Math.random() * index
                 }
                 columns={createColumns(filter)}
-                dataSource={events}
+                dataSource={addTimestamp}
                 loading={isLoading}
               />
             </ConfigProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -210,6 +210,7 @@ function App() {
                 columns={createColumns(filter)}
                 dataSource={updatedEventsTime}
                 loading={isLoading}
+                scroll={{ x: 400 }}
               />
             </ConfigProvider>
           )}

--- a/src/App.js
+++ b/src/App.js
@@ -35,7 +35,10 @@ function App() {
   const [events, setEvents] = useState([]);
   const [contractAddress, setContractAddress] = useState();
   const [abiError, setAbiError] = useState(false);
+  const [blockNumbers, setBlockNumbers] = useState([]);
   const inputRef = useRef(null);
+
+  console.log(blockNumbers);
 
   const { contractEvents, isLoading, isError } = GetData(contractAddress);
 
@@ -75,6 +78,8 @@ function App() {
     value: event,
   }));
 
+  console.log(events.filter.blockNumber);
+
   const customizeRenderEmpty = () => (
     <Empty
       image={Empty.PRESENTED_IMAGE_SIMPLE}
@@ -101,14 +106,26 @@ function App() {
           setAbiError(false);
         }
       };
+
       getError();
+
       const { abi } = contractEvents;
       const contract = new ethers.Contract(contractAddress, abi, provider);
       const queryResult = await contract.queryFilter(contract.filters);
       setEvents(queryResult);
     };
     getEvents();
-  }, [contractAddress, contractEvents, isError]);
+
+    const getBlocks = async () => {
+      const provider = new ethers.providers.AlchemyProvider();
+      const getBlocks = provider.getBlock(events.filters.blockNumber);
+      setBlockNumbers(getBlocks);
+      // const timestamp = (await getBlocks).timestamp;
+      // console.log(timestamp);
+    };
+
+    getBlocks();
+  }, [contractAddress, contractEvents, isError, events.filters.blockNumber]);
 
   return (
     <Layout style={{ minHeight: "100vh" }}>

--- a/src/App.js
+++ b/src/App.js
@@ -38,12 +38,10 @@ function App() {
   const [timestamps, setTimestamps] = useState([]);
   const inputRef = useRef(null);
 
-  const addTimestamp = events.map((event, index) => ({
+  const updatedEventsTime = events.map((event, index) => ({
     ...event,
     timestamp: timestamps[index],
   }));
-
-  console.log(addTimestamp);
 
   const { contractEvents, isLoading, isError } = GetData(contractAddress);
 
@@ -123,7 +121,6 @@ function App() {
       setEvents(queryResult);
 
       const eventBlocks = queryResult.map((item) => item.blockNumber);
-      // const uniqueBlocks = [...new Set(eventBlocks)];
 
       const timestampArr = [];
 
@@ -132,7 +129,8 @@ function App() {
           const time = await provider.getBlock(block);
           const timestamp = time.timestamp;
           const date = new Date(timestamp * 1000);
-          timestampArr.push(date);
+          const newDate = date.toString();
+          timestampArr.push(newDate);
         }
         setTimestamps(timestampArr);
       }
@@ -203,7 +201,7 @@ function App() {
                   record.logIndex + Math.random() * index
                 }
                 columns={createColumns(filter)}
-                dataSource={addTimestamp}
+                dataSource={updatedEventsTime}
                 loading={isLoading}
               />
             </ConfigProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8771,6 +8771,11 @@ readable-stream@^3.0.6:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readable-timestamp-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/readable-timestamp-js/-/readable-timestamp-js-1.0.2.tgz#475ae594995dc4c34408d5276151fd90b4111646"
+  integrity sha512-sGQ9FINFN0Bcbu6TtuDXgKcIERWt/QVzC4y7Mcnt6yt/hvrYvAYvLPfGQ4Lzf2aYcXeVFa4hqGK6o4/EqqAFvg==
+
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"


### PR DESCRIPTION
Issue: Add human readable timestamp to each block

I used the ethers API to pull the timestamp of each block and appended it to the events data to display in the table. I converted it from UNIX time using readable-timestamp-js package to make it human-readable.

Testing:
- [x] Used different addresses to confirm the table populates correctly (0xe34c023c0ea9899a8f8e9381437a604908e8b719; 0x75d078248eE49c585b73E73ab08bb3eaF93383Ae)
- [x] Checked transactions at random against etherscan to confirm correct date/time
- [x] Tested error and loading states and other event information to confirm the changes did not break them